### PR TITLE
Fix build problem in Ubuntu 18. GetSimTime funct deprecated in Gazebo 8

### DIFF
--- a/gazebo_animator/src/joint_animator_gazebo_plugin.cpp
+++ b/gazebo_animator/src/joint_animator_gazebo_plugin.cpp
@@ -43,7 +43,7 @@ void JointAnimatorGazeboPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _
         ros::VoidPtr(), &this->queue_);
     this->sub_ = this->rosnode_->subscribe(joint_state_so);
 
-    this->last_time_ = this->world_->GetSimTime();
+    this->last_time_ = this->world_->SimTime();
 
     // start custom queue for joint state plugin ros topics
     this->callback_queue_thread_ = boost::thread(boost::bind(&JointAnimatorGazeboPlugin::QueueThread, this));

--- a/gazebo_animator/src/joint_animator_gazebo_plugin.cpp
+++ b/gazebo_animator/src/joint_animator_gazebo_plugin.cpp
@@ -43,7 +43,11 @@ void JointAnimatorGazeboPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _
         ros::VoidPtr(), &this->queue_);
     this->sub_ = this->rosnode_->subscribe(joint_state_so);
 
-    this->last_time_ = this->world_->SimTime();
+    #if GAZEBO_MAJOR_VERSION >= 8
+        this->last_time_ = this->world_->SimTime();
+    #else
+        this->last_time_ = this->world_->GetSimTime();
+    #endif
 
     // start custom queue for joint state plugin ros topics
     this->callback_queue_thread_ = boost::thread(boost::bind(&JointAnimatorGazeboPlugin::QueueThread, this));


### PR DESCRIPTION
Before the merge of this branch I would like to discuss if it has sense, to avoid possible changes which could affect to users simulations.

If we will start to use Ubuntu 18 the GetSimTime function does not exists since Gazebo 8 and was replaced by SimTime ([link](https://bitbucket.org/osrf/gazebo/src/fdc943f62e1ef3fdd74df1b0b0863993d1694fe1/gazebo/physics/World.hh?at=gazebo9&fileviewer=file-view-default#World.hh-219))